### PR TITLE
feat: Simplify output formats to Text + JSON only (fixes #20)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -71,7 +71,6 @@ program
   .option('--sort <field>', 'sort by field[:order]', 'name')
   .option('--limit <num>', 'limit number of results', '50')
   .option('--json', 'output as JSON')
-  .option('--csv', 'output as CSV')
   .option('--threshold-violations', 'show functions that violate configurable thresholds')
   .action(listCommand);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -254,12 +254,11 @@ export interface ListCommandOptions extends CommandOptions {
   complexity?: string;
   lines?: string;
   params?: string;
-  format?: 'table' | 'json' | 'csv' | 'friendly';
+  format?: 'table' | 'json' | 'friendly';
   fields?: string;
   sort?: string;
   limit?: string;
   json?: boolean;
-  csv?: boolean;
   thresholdViolations?: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Remove CSV output functionality as outlined in v2.0 design overhaul
- Simplify output formats to Text + JSON only for better maintainability  
- Refactor complex functions to improve code quality

## Changes Made
- ✅ Removed `--csv` CLI option from list command
- ✅ Removed CSV output format and related formatting code
- ✅ Refactored `outputFriendly` function to reduce complexity (eliminated High Risk function)
- ✅ Maintained comprehensive JSON output for external tool integration
- ✅ All tests pass and code quality improved (0 High Risk functions)

## Test Plan
- [x] All unit tests pass (`npm test`)
- [x] TypeScript compilation succeeds (`npm run typecheck`)
- [x] Code quality metrics improved (0 High Risk functions)
- [x] JSON output remains comprehensive for external tool integration
- [x] Text output (table/friendly) functions correctly

## Impact
This change simplifies funcqc by removing CSV output complexity while maintaining rich JSON output for ecosystem integration. External tools can now handle specialized formatting, aligning with v2.0 design principles.

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能の削除**
  * CLIの`list`コマンドからCSV出力オプションが削除され、CSV形式での出力が利用できなくなりました。

* **リファクタリング**
  * 出力表示の処理が複数の小さな関数に分割され、可読性と保守性が向上しました。機能や出力内容に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->