### PR TITLE
fix: Simplify type casting in PGLite Storage getANNIndexStats method

### DIFF
--- a/src/storage/pglite-adapter.ts
+++ b/src/storage/pglite-adapter.ts
@@ -1193,17 +1193,26 @@ export class PGLiteStorageAdapter implements StorageAdapter {
         embedding_model: string;
       };
 
-      const currentIndex = currentResult.rows.length > 0 ? {
-        algorithm: (currentResult.rows[0] as CurrentIndexRow).algorithm,
-        vectorCount: (currentResult.rows[0] as CurrentIndexRow).vector_count,
-        buildTimeMs: (currentResult.rows[0] as CurrentIndexRow).build_time_ms,
-        model: (currentResult.rows[0] as CurrentIndexRow).embedding_model
-      } : null;
+      type TotalRow = { total: number };
+      type AvgTimeRow = { avg_time: number };
+
+      const currentIndex = currentResult.rows.length > 0 ? (() => {
+        const row = currentResult.rows[0] as CurrentIndexRow;
+        return {
+          algorithm: row.algorithm,
+          vectorCount: row.vector_count,
+          buildTimeMs: row.build_time_ms,
+          model: row.embedding_model
+        };
+      })() : null;
+
+      const totalRow = totalResult.rows[0] as TotalRow;
+      const avgRow = avgResult.rows[0] as AvgTimeRow;
 
       return {
-        totalIndexes: (totalResult.rows[0] as { total: number }).total,
+        totalIndexes: totalRow.total,
         currentIndex,
-        averageBuildTime: (avgResult.rows[0] as { avg_time: number }).avg_time || 0
+        averageBuildTime: avgRow.avg_time || 0
       };
     } catch (error) {
       throw new Error(`Failed to get ANN index stats: ${error instanceof Error ? error.message : String(error)}`);


### PR DESCRIPTION
## Summary
Simplifies repetitive type casting in the `getANNIndexStats` method of PGLite Storage adapter for better maintainability and readability.

## Changes Made
- Pre-declared type definitions for `TotalRow` and `AvgTimeRow` to match existing pattern
- Extracted row data once using const assignment to avoid repetitive type casting
- Used IIFE (Immediately Invoked Function Expression) pattern for cleaner conditional assignment
- Eliminated verbose repeated type assertions

## Benefits
- **Improved readability**: Less verbose type casting throughout the method
- **Better maintainability**: Centralized type definitions make future changes easier
- **Reduced duplication**: Single type cast per result set instead of multiple assertions
- **Consistent pattern**: Follows the same approach used for `CurrentIndexRow`

## Testing
- ✅ All existing tests pass
- ✅ TypeScript compilation successful
- ✅ ESLint validation passes
- ✅ No breaking changes to public API

## Before vs After
**Before:** Repetitive type casting on every property access
```typescript
totalIndexes: (totalResult.rows[0] as { total: number }).total,
averageBuildTime: (avgResult.rows[0] as { avg_time: number }).avg_time || 0
```

**After:** Clean, single type cast with extracted data
```typescript
const totalRow = totalResult.rows[0] as TotalRow;
const avgRow = avgResult.rows[0] as AvgTimeRow;

return {
  totalIndexes: totalRow.total,
  averageBuildTime: avgRow.avg_time || 0
};
```

Fixes #60

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **リファクタリング**
  * 内部処理の明確化と変数名の改善により、統計情報取得の信頼性と可読性が向上しました。ユーザー向けの動作や表示に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->