### PR TITLE
Fix issue #84: Support multi-field sorting in list command

### DIFF
--- a/src/storage/pglite-adapter.ts
+++ b/src/storage/pglite-adapter.ts
@@ -225,11 +225,25 @@ export class PGLiteStorageAdapter implements StorageAdapter {
         ['display_name', 'f.display_name']
       ]);
       
-      const sortColumn = options?.sort && validSortFields.has(options.sort) 
-        ? validSortFields.get(options.sort)!
-        : 'f.start_line';
+      // Handle multi-field sorting (e.g., 'file_path,start_line')
+      let orderByClause = 'f.start_line'; // default
       
-      sql += ` ORDER BY ${sortColumn}`;
+      if (options?.sort) {
+        const sortFields = options.sort.split(',').map(field => field.trim());
+        const validOrderByFields: string[] = [];
+        
+        for (const field of sortFields) {
+          if (validSortFields.has(field)) {
+            validOrderByFields.push(validSortFields.get(field)!);
+          }
+        }
+        
+        if (validOrderByFields.length > 0) {
+          orderByClause = validOrderByFields.join(', ');
+        }
+      }
+      
+      sql += ` ORDER BY ${orderByClause}`;
 
       // Add pagination
       if (options?.limit) {


### PR DESCRIPTION
## Summary
- Enhanced storage adapter to parse comma-separated sort fields in query options
- Fixed list command sorting that was defaulting to start_line only instead of 'file_path,start_line'
- Functions are now correctly grouped by file path first, then sorted by start line within each file
- Maintains full backward compatibility for single-field sorting used in other commands

## Changes Made
- Modified `getFunctions` method in `PGLiteStorageAdapter` to support multi-field sorting
- Added logic to split comma-separated sort fields and validate each field against `validSortFields`
- Preserved existing behavior for single-field sorting to ensure no breaking changes

## Test Results
- All existing tests pass (265/265)
- TypeScript compilation succeeds with no errors
- ESLint validation passes
- Manual testing confirms functions are now grouped by file path as expected

## Before Fix
Functions were sorted only by start line, mixing files:
```
ID       Name                            CC File                                     Location
553cecf3 showCommand                      4 src/cli/show.ts                          6-24
41f98737 statusCommand                    7 src/cli/status.ts                        8-33
7568f2d1 calculate                        1 src/metrics/quality-calculator.ts        9-67
```

## After Fix
Functions are grouped by file path, then sorted by start line:
```
ID       Name                            CC File                                     Location
98257380 analyze                          1 src/analyzers/naming-quality-analyzer.ts 54-88
af36b565 parseToAST                       1 src/analyzers/naming-quality-analyzer.ts 93-121
f3157412 createParseableSource            2 src/analyzers/naming-quality-analyzer.ts 126-139
```

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数のフィールドによる並び替えに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->