### PR TITLE
Fix issue #86: Replace table library with simple output in history command

### DIFF
--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -1,5 +1,4 @@
 import chalk from 'chalk';
-import { table } from 'table';
 import { ConfigManager } from '../core/config';
 import { PGLiteStorageAdapter } from '../storage/pglite-adapter';
 import { Logger } from '../utils/cli-utils';
@@ -98,48 +97,22 @@ async function displaySnapshotHistory(
 }
 
 function displayCompactHistory(snapshots: SnapshotInfo[]): void {
-  const tableData = snapshots.map(snapshot => [
-    snapshot.id.substring(0, 8),
-    snapshot.label || '-',
-    formatDate(snapshot.createdAt),
-    snapshot.gitBranch || '-',
-    snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-',
-    snapshot.metadata.totalFunctions.toString(),
-    snapshot.metadata.avgComplexity.toFixed(1)
-  ]);
-
-  const headers = [
-    'ID',
-    'Label',
-    'Created',
-    'Branch',
-    'Commit',
-    'Functions',
-    'Avg Complexity'
-  ];
-
-  const config = {
-    header: {
-      alignment: 'center' as const,
-      content: headers.map(h => chalk.bold(h))
-    },
-    columnDefault: {
-      paddingLeft: 1,
-      paddingRight: 1,
-    },
-    columns: {
-      0: { alignment: 'left' as const },
-      1: { alignment: 'left' as const },
-      2: { alignment: 'left' as const },
-      3: { alignment: 'left' as const },
-      4: { alignment: 'left' as const },
-      5: { alignment: 'right' as const },
-      6: { alignment: 'right' as const }
-    }
-  };
-
-  // @ts-expect-error - Table configuration type issue
-  console.log(table([headers, ...tableData], config));
+  // Display header with fixed-width columns
+  console.log('ID       Label                     Created              Branch      Commit  Functions  Avg CC');
+  console.log('-------- ------------------------- -------------------- ----------- ------- ---------- ------');
+  
+  // Display each snapshot
+  for (const snapshot of snapshots) {
+    const id = snapshot.id.substring(0, 8);
+    const label = (snapshot.label || '-').substring(0, 25).padEnd(25);
+    const created = formatDate(snapshot.createdAt).substring(0, 20).padEnd(20);
+    const branch = (snapshot.gitBranch || '-').substring(0, 11).padEnd(11);
+    const commit = (snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-').padEnd(7);
+    const functions = snapshot.metadata.totalFunctions.toString().padStart(10);
+    const avgComplexity = snapshot.metadata.avgComplexity.toFixed(1).padStart(6);
+    
+    console.log(`${id} ${label} ${created} ${branch} ${commit} ${functions} ${avgComplexity}`);
+  }
 }
 
 async function displayDetailedHistory(
@@ -398,56 +371,26 @@ function displayCompactFunctionHistory(
   history: Array<{ snapshot: SnapshotInfo; function: FunctionInfo | null; isPresent: boolean }>,
   _functionName: string
 ): void {
-  const tableData = history.map(entry => {
+  // Display header with fixed-width columns
+  console.log('Snapshot Date                 Branch      Commit  Present    CC    LOC  Trend');
+  console.log('-------- -------------------- ----------- ------- ------- ----- ------ ------');
+  
+  // Display each history entry
+  for (const entry of history) {
     const snapshot = entry.snapshot;
     const func = entry.function;
     
-    return [
-      snapshot.id.substring(0, 8),
-      formatDate(snapshot.createdAt),
-      snapshot.gitBranch || '-',
-      snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-',
-      entry.isPresent ? chalk.green('✓') : chalk.red('✗'),
-      func?.metrics?.cyclomaticComplexity?.toString() || '-',
-      func?.metrics?.linesOfCode?.toString() || '-',
-      calculateQualityTrend(func)
-    ];
-  });
-
-  const headers = [
-    'Snapshot',
-    'Date',
-    'Branch',
-    'Commit',
-    'Present',
-    'Complexity',
-    'LOC',
-    'Trend'
-  ];
-
-  const config = {
-    header: {
-      alignment: 'center' as const,
-      content: headers.map(h => chalk.bold(h))
-    },
-    columnDefault: {
-      paddingLeft: 1,
-      paddingRight: 1,
-    },
-    columns: {
-      0: { alignment: 'left' as const },
-      1: { alignment: 'left' as const },
-      2: { alignment: 'left' as const },
-      3: { alignment: 'left' as const },
-      4: { alignment: 'center' as const },
-      5: { alignment: 'right' as const },
-      6: { alignment: 'right' as const },
-      7: { alignment: 'center' as const }
-    }
-  };
-
-  // @ts-expect-error - Table configuration type issue
-  console.log(table([headers, ...tableData], config));
+    const id = snapshot.id.substring(0, 8);
+    const date = formatDate(snapshot.createdAt).substring(0, 20).padEnd(20);
+    const branch = (snapshot.gitBranch || '-').substring(0, 11).padEnd(11);
+    const commit = (snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-').padEnd(7);
+    const present = entry.isPresent ? chalk.green('✓').padEnd(7) : chalk.red('✗').padEnd(7);
+    const cc = (func?.metrics?.cyclomaticComplexity?.toString() || '-').padStart(5);
+    const loc = (func?.metrics?.linesOfCode?.toString() || '-').padStart(6);
+    const trend = calculateQualityTrend(func).padEnd(6);
+    
+    console.log(`${id} ${date} ${branch} ${commit} ${present} ${cc} ${loc}  ${trend}`);
+  }
 }
 
 function displayDetailedFunctionHistory(

--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -98,15 +98,15 @@ async function displaySnapshotHistory(
 
 function displayCompactHistory(snapshots: SnapshotInfo[]): void {
   // Display header with fixed-width columns
-  console.log('ID       Label                     Created              Branch      Commit  Functions  Avg CC');
-  console.log('-------- ------------------------- -------------------- ----------- ------- ---------- ------');
+  console.log('ID       Label                     Created              Branch           Commit  Functions  Avg CC');
+  console.log('-------- ------------------------- -------------------- --------------- ------- ---------- ------');
   
   // Display each snapshot
   for (const snapshot of snapshots) {
     const id = snapshot.id.substring(0, 8);
     const label = (snapshot.label || '-').substring(0, 25).padEnd(25);
     const created = formatDate(snapshot.createdAt).substring(0, 20).padEnd(20);
-    const branch = (snapshot.gitBranch || '-').substring(0, 11).padEnd(11);
+    const branch = (snapshot.gitBranch || '-').substring(0, 15).padEnd(15);
     const commit = (snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-').padEnd(7);
     const functions = snapshot.metadata.totalFunctions.toString().padStart(10);
     const avgComplexity = snapshot.metadata.avgComplexity.toFixed(1).padStart(6);
@@ -372,8 +372,8 @@ function displayCompactFunctionHistory(
   _functionName: string
 ): void {
   // Display header with fixed-width columns
-  console.log('Snapshot Date                 Branch      Commit  Present    CC    LOC  Trend');
-  console.log('-------- -------------------- ----------- ------- ------- ----- ------ ------');
+  console.log('Snapshot Date                 Branch           Commit  Present    CC    LOC  Trend');
+  console.log('-------- -------------------- --------------- ------- ------- ----- ------ ------');
   
   // Display each history entry
   for (const entry of history) {
@@ -382,7 +382,7 @@ function displayCompactFunctionHistory(
     
     const id = snapshot.id.substring(0, 8);
     const date = formatDate(snapshot.createdAt).substring(0, 20).padEnd(20);
-    const branch = (snapshot.gitBranch || '-').substring(0, 11).padEnd(11);
+    const branch = (snapshot.gitBranch || '-').substring(0, 15).padEnd(15);
     const commit = (snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-').padEnd(7);
     const present = entry.isPresent ? chalk.green('✓').padEnd(7) : chalk.red('✗').padEnd(7);
     const cc = (func?.metrics?.cyclomaticComplexity?.toString() || '-').padStart(5);

--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -96,6 +96,14 @@ async function displaySnapshotHistory(
   displayHistorySummary(filteredSnapshots);
 }
 
+function truncateWithEllipsis(str: string, maxLength: number): string {
+  if (!str || str.length <= maxLength) {
+    return str;
+  }
+  // Reserve 3 characters for ellipsis
+  return str.substring(0, maxLength - 3) + '...';
+}
+
 function displayCompactHistory(snapshots: SnapshotInfo[]): void {
   // Display header with fixed-width columns
   console.log('ID       Label                     Created              Branch           Commit  Functions  Avg CC');
@@ -104,9 +112,9 @@ function displayCompactHistory(snapshots: SnapshotInfo[]): void {
   // Display each snapshot
   for (const snapshot of snapshots) {
     const id = snapshot.id.substring(0, 8);
-    const label = (snapshot.label || '-').substring(0, 25).padEnd(25);
-    const created = formatDate(snapshot.createdAt).substring(0, 20).padEnd(20);
-    const branch = (snapshot.gitBranch || '-').substring(0, 15).padEnd(15);
+    const label = truncateWithEllipsis(snapshot.label || '-', 25).padEnd(25);
+    const created = truncateWithEllipsis(formatDate(snapshot.createdAt), 20).padEnd(20);
+    const branch = truncateWithEllipsis(snapshot.gitBranch || '-', 15).padEnd(15);
     const commit = (snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-').padEnd(7);
     const functions = snapshot.metadata.totalFunctions.toString().padStart(10);
     const avgComplexity = snapshot.metadata.avgComplexity.toFixed(1).padStart(6);
@@ -381,8 +389,8 @@ function displayCompactFunctionHistory(
     const func = entry.function;
     
     const id = snapshot.id.substring(0, 8);
-    const date = formatDate(snapshot.createdAt).substring(0, 20).padEnd(20);
-    const branch = (snapshot.gitBranch || '-').substring(0, 15).padEnd(15);
+    const date = truncateWithEllipsis(formatDate(snapshot.createdAt), 20).padEnd(20);
+    const branch = truncateWithEllipsis(snapshot.gitBranch || '-', 15).padEnd(15);
     const commit = (snapshot.gitCommit ? snapshot.gitCommit.substring(0, 7) : '-').padEnd(7);
     const present = entry.isPresent ? chalk.green('✓').padEnd(7) : chalk.red('✗').padEnd(7);
     const cc = (func?.metrics?.cyclomaticComplexity?.toString() || '-').padStart(5);


### PR DESCRIPTION
## Summary
- Removed problematic `table` library usage that was causing runtime errors
- Implemented simple fixed-width column output following Unix philosophy
- Made history command output pipe-friendly for use with standard Unix tools

## Changes Made
1. **Removed table library dependency** from history command
2. **Implemented fixed-width column output** for both:
   - Snapshot history display (`displayCompactHistory`)
   - Function history display (`displayCompactFunctionHistory`)
3. **Maintained all existing functionality**:
   - Verbose mode still works
   - All filtering options (`--label`, `--branch`, etc.) continue to work
   - Function-specific history (`--id`) works correctly

## Before Fix
```
config {
  header: {
    alignment: 'center',
    content: [...]
  },
  ...
}
errors [
  {
    message: 'must be string',
    params: { type: 'string' },
    schemaPath: '#/properties/header/properties/content/type'
  }
]
❌ Error: Failed to retrieve history
```

## After Fix
```
📈 Snapshot History (3 snapshots)

ID       Label                     Created              Branch      Commit  Functions  Avg CC
-------- ------------------------- -------------------- ----------- ------- ---------- ------
snap_175 test-fix-86               9h ago               fix-issue-8 7b79809        908    2.3
snap_175 -                         16h ago              fix-issue-8 bf00132        908    2.3
snap_175 -                         2d ago               fix-issue-7 27ad0ba        936    2.4
```

## Test Results
- ✅ `npm run dev history` displays correctly
- ✅ `npm run dev -- history --label "test"` filters work
- ✅ `npm run dev -- history --id "function-id"` function history works
- ✅ Output can be piped: `npm run dev history  < /dev/null |  grep "test"`
- ✅ TypeScript compilation passes
- ✅ ESLint validation passes

## Unix Philosophy Benefits
- Simple text output that can be processed with standard tools
- Pipe-friendly format for grep, awk, sed, etc.
- No external dependencies for table rendering
- Consistent with the approach used in list command

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **リファクタリング**
  * 履歴表示のテーブル出力方法を外部ライブラリ依存から手動の文字列整形に変更し、同じ内容を固定幅カラムで表示するようになりました。表示内容や並び順に変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->