### PR TITLE
Add lineage deletion commands for managing false positives

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -500,6 +500,42 @@ Examples:
   $ funcqc lineage review abc12345 --reject --note "Incorrect mapping"
   $ funcqc lineage review --all --approve        # Approve all draft lineages
 `)
+  )
+  .addCommand(
+    new Command('delete')
+      .description('Delete a specific lineage')
+      .argument('<lineage-id>', 'lineage ID to delete')
+      .action(async (lineageId: string, options: OptionValues) => {
+        const { lineageDeleteCommand } = await import('./cli/lineage');
+        await lineageDeleteCommand(lineageId, options);
+      })
+      .addHelpText('after', `
+Examples:
+  $ funcqc lineage delete abc12345               # Delete specific lineage
+  $ funcqc lineage delete abc12345 -v            # Delete with verbose output
+`)
+  )
+  .addCommand(
+    new Command('clean')
+      .description('Delete lineages matching criteria')
+      .option('--status <status>', 'filter by status (default: draft)')
+      .option('--older-than <days>', 'delete lineages older than N days')
+      .option('--dry-run', 'preview what would be deleted without making changes')
+      .option('-y, --yes', 'skip confirmation prompt')
+      .option('--include-approved', 'include approved lineages (requires --force)')
+      .option('--force', 'required flag when deleting approved lineages')
+      .action(async (options: OptionValues) => {
+        const { lineageCleanCommand } = await import('./cli/lineage');
+        await lineageCleanCommand(options);
+      })
+      .addHelpText('after', `
+Examples:
+  $ funcqc lineage clean                         # Delete all draft lineages
+  $ funcqc lineage clean --dry-run               # Preview what would be deleted
+  $ funcqc lineage clean --older-than 30         # Delete drafts older than 30 days
+  $ funcqc lineage clean -y                      # Skip confirmation
+  $ funcqc lineage clean --include-approved --force  # Delete including approved (dangerous!)
+`)
   );
 
 // Add explain command

--- a/test/cli/lineage-delete.test.ts
+++ b/test/cli/lineage-delete.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { lineageDeleteCommand, lineageCleanCommand } from '../../src/cli/lineage';
+import { Logger } from '../../src/utils/cli-utils';
+import { ConfigManager } from '../../src/core/config';
+import { PGLiteStorageAdapter } from '../../src/storage/pglite-adapter';
+import { Lineage } from '../../src/types';
+import * as readline from 'readline';
+
+// Mock dependencies
+vi.mock('../../src/core/config');
+vi.mock('../../src/storage/pglite-adapter');
+vi.mock('../../src/utils/cli-utils');
+vi.mock('readline');
+
+describe('lineage delete command', () => {
+  let mockStorage: any;
+  let mockLogger: any;
+  let mockReadline: any;
+
+  beforeEach(() => {
+    mockStorage = {
+      init: vi.fn(),
+      close: vi.fn(),
+      getLineage: vi.fn(),
+      deleteLineage: vi.fn(),
+      getLineages: vi.fn(),
+    };
+
+    mockLogger = {
+      error: vi.fn(),
+      info: vi.fn(),
+      success: vi.fn(),
+      warn: vi.fn(),
+    };
+
+    mockReadline = {
+      question: vi.fn(),
+      close: vi.fn(),
+    };
+
+    vi.mocked(ConfigManager).mockImplementation(() => ({
+      load: vi.fn().mockResolvedValue({ storage: { path: '/test/path' } }),
+    } as any));
+
+    vi.mocked(PGLiteStorageAdapter).mockImplementation(() => mockStorage);
+    vi.mocked(Logger).mockImplementation(() => mockLogger);
+    vi.mocked(readline.createInterface).mockReturnValue(mockReadline);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('lineageDeleteCommand', () => {
+    it('should error when lineage not found', async () => {
+      mockStorage.getLineage.mockResolvedValue(null);
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation((code?: any) => {
+        throw new Error(`Process exited with code ${code}`);
+      });
+
+      await expect(lineageDeleteCommand('test-id', {})).rejects.toThrow('Process exited with code 1');
+      
+      expect(mockLogger.error).toHaveBeenCalledWith('Lineage not found: test-id');
+      mockExit.mockRestore();
+    });
+
+    it('should delete draft lineage with confirmation', async () => {
+      const mockLineage: Lineage = {
+        id: 'test-id',
+        fromIds: ['func1'],
+        toIds: ['func2'],
+        kind: 'rename',
+        status: 'draft',
+        confidence: 0.9,
+        gitCommit: 'abc123',
+        createdAt: new Date(),
+      };
+
+      mockStorage.getLineage.mockResolvedValue(mockLineage);
+      mockStorage.deleteLineage.mockResolvedValue(true);
+      mockReadline.question.mockImplementation((prompt: string, callback: (answer: string) => void) => {
+        callback('y');
+      });
+
+      await lineageDeleteCommand('test-id', {});
+
+      expect(mockStorage.deleteLineage).toHaveBeenCalledWith('test-id');
+      expect(mockLogger.success).toHaveBeenCalledWith('Lineage test-id has been deleted.');
+    });
+
+    it('should show extra warning for approved lineage', async () => {
+      const mockLineage: Lineage = {
+        id: 'test-id',
+        fromIds: ['func1'],
+        toIds: ['func2'],
+        kind: 'rename',
+        status: 'approved',
+        confidence: 0.9,
+        gitCommit: 'abc123',
+        createdAt: new Date(),
+      };
+
+      mockStorage.getLineage.mockResolvedValue(mockLineage);
+      mockStorage.deleteLineage.mockResolvedValue(true);
+      mockReadline.question.mockImplementation((prompt: string, callback: (answer: string) => void) => {
+        // Require 'yes' for approved lineages
+        callback('yes');
+      });
+
+      await lineageDeleteCommand('test-id', {});
+
+      expect(mockReadline.question).toHaveBeenCalledWith(
+        expect.stringContaining('Type "yes" to confirm'),
+        expect.any(Function)
+      );
+    });
+
+    it('should cancel deletion when not confirmed', async () => {
+      const mockLineage: Lineage = {
+        id: 'test-id',
+        fromIds: ['func1'],
+        toIds: ['func2'],
+        kind: 'rename',
+        status: 'draft',
+        confidence: 0.9,
+        gitCommit: 'abc123',
+        createdAt: new Date(),
+      };
+
+      mockStorage.getLineage.mockResolvedValue(mockLineage);
+      mockReadline.question.mockImplementation((prompt: string, callback: (answer: string) => void) => {
+        callback('n');
+      });
+
+      await lineageDeleteCommand('test-id', {});
+
+      expect(mockStorage.deleteLineage).not.toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith('Deletion cancelled.');
+    });
+  });
+
+  describe('lineageCleanCommand', () => {
+    it('should delete draft lineages by default', async () => {
+      const mockLineages: Lineage[] = [
+        {
+          id: 'draft1',
+          fromIds: ['func1'],
+          toIds: ['func2'],
+          kind: 'rename',
+          status: 'draft',
+          confidence: 0.9,
+          gitCommit: 'abc123',
+          createdAt: new Date(),
+        },
+        {
+          id: 'draft2',
+          fromIds: ['func3'],
+          toIds: ['func4'],
+          kind: 'split',
+          status: 'draft',
+          confidence: 0.8,
+          gitCommit: 'def456',
+          createdAt: new Date(),
+        },
+      ];
+
+      mockStorage.getLineages.mockResolvedValue(mockLineages);
+      mockStorage.deleteLineage.mockResolvedValue(true);
+      mockReadline.question.mockImplementation((prompt: string, callback: (answer: string) => void) => {
+        callback('y');
+      });
+
+      await lineageCleanCommand({});
+
+      expect(mockStorage.getLineages).toHaveBeenCalledWith({ status: 'draft' });
+      expect(mockStorage.deleteLineage).toHaveBeenCalledTimes(2);
+      expect(mockLogger.success).toHaveBeenCalledWith('Deleted 2 lineages.');
+    });
+
+    it('should support dry run mode', async () => {
+      const mockLineages: Lineage[] = [
+        {
+          id: 'draft1',
+          fromIds: ['func1'],
+          toIds: ['func2'],
+          kind: 'rename',
+          status: 'draft',
+          confidence: 0.9,
+          gitCommit: 'abc123',
+          createdAt: new Date(),
+        },
+      ];
+
+      mockStorage.getLineages.mockResolvedValue(mockLineages);
+
+      await lineageCleanCommand({ dryRun: true });
+
+      expect(mockStorage.deleteLineage).not.toHaveBeenCalled();
+    });
+
+    it('should filter by older-than days', async () => {
+      const oldDate = new Date();
+      oldDate.setDate(oldDate.getDate() - 40);
+      
+      const mockLineages: Lineage[] = [
+        {
+          id: 'old',
+          fromIds: ['func1'],
+          toIds: ['func2'],
+          kind: 'rename',
+          status: 'draft',
+          confidence: 0.9,
+          gitCommit: 'abc123',
+          createdAt: oldDate,
+        },
+        {
+          id: 'recent',
+          fromIds: ['func3'],
+          toIds: ['func4'],
+          kind: 'split',
+          status: 'draft',
+          confidence: 0.8,
+          gitCommit: 'def456',
+          createdAt: new Date(),
+        },
+      ];
+
+      mockStorage.getLineages.mockResolvedValue(mockLineages);
+      mockStorage.deleteLineage.mockResolvedValue(true);
+      mockReadline.question.mockImplementation((prompt: string, callback: (answer: string) => void) => {
+        callback('y');
+      });
+
+      await lineageCleanCommand({ olderThan: '30' });
+
+      expect(mockStorage.deleteLineage).toHaveBeenCalledTimes(1);
+      expect(mockStorage.deleteLineage).toHaveBeenCalledWith('old');
+    });
+
+    it('should require force flag for approved lineages', async () => {
+      const mockExit = vi.spyOn(process, 'exit').mockImplementation((code?: any) => {
+        throw new Error(`Process exited with code ${code}`);
+      });
+
+      await expect(lineageCleanCommand({ includeApproved: true })).rejects.toThrow('Process exited with code 1');
+      
+      expect(mockLogger.error).toHaveBeenCalledWith('--include-approved requires --force flag for safety');
+      mockExit.mockRestore();
+    });
+
+    it('should skip confirmation with --yes flag', async () => {
+      const mockLineages: Lineage[] = [
+        {
+          id: 'draft1',
+          fromIds: ['func1'],
+          toIds: ['func2'],
+          kind: 'rename',
+          status: 'draft',
+          confidence: 0.9,
+          gitCommit: 'abc123',
+          createdAt: new Date(),
+        },
+      ];
+
+      mockStorage.getLineages.mockResolvedValue(mockLineages);
+      mockStorage.deleteLineage.mockResolvedValue(true);
+
+      await lineageCleanCommand({ yes: true });
+
+      expect(mockReadline.question).not.toHaveBeenCalled();
+      expect(mockStorage.deleteLineage).toHaveBeenCalledWith('draft1');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Adds individual and batch deletion commands to manage lineage false positives and cleanup operations.

- **Individual deletion**: `funcqc lineage delete <id>` - Delete specific lineage with confirmation
- **Batch deletion**: `funcqc lineage clean [options]` - Delete lineages by criteria

## Key Features

### Safety Controls
- Confirmation prompts for all deletions
- Extra warnings for approved lineages (require "yes" confirmation)
- Default protection: only deletes draft lineages unless explicitly overridden
- Force flag required for including approved lineages

### Flexible Cleanup Options
- `--dry-run` mode for preview
- Time-based filtering with `--older-than <days>`
- Status filtering (`--status draft < /dev/null | approved|rejected`)
- Skip confirmation with `--yes` flag

### Use Cases
1. **Remove false positives** after fixing detection logic
2. **Regular maintenance** - clean up old draft lineages  
3. **Storage management** - reduce database size
4. **Project reset** - clear lineages when restructuring

## Testing
- Comprehensive unit tests with mocked dependencies
- Manual testing confirmed proper CLI behavior
- TypeScript compilation and lint checks passed

## Documentation
- Updated `docs/lineage-cli-commands.md` with complete examples
- Added maintenance workflow examples
- Documented safety features and use cases

## Examples

```bash
# Delete specific lineage
funcqc lineage delete abc12345

# Clean up old drafts (safe)
funcqc lineage clean --older-than 30

# Preview all drafts to be deleted
funcqc lineage clean --dry-run

# Emergency cleanup of all drafts
funcqc lineage clean --yes
```

Fixes #155

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * コマンドラインツールに「lineage delete」と「lineage clean」コマンドが追加され、個別または条件指定による系統情報の削除が可能になりました。確認プロンプトやドライラン、詳細出力、承認済みデータの安全な削除オプションも利用できます。

* **ドキュメント**
  * 新コマンドの使い方やオプション、利用例がドキュメントに追加されました。

* **テスト**
  * 新コマンドの動作やエラーハンドリング、ユーザー確認フローを検証するテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->