### PR TITLE
feat: Add call_edges table schema for call graph analysis

### DIFF
--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -122,6 +122,23 @@ export interface MetricsRow {
   maintainability_index?: number;
 }
 
+export interface CallEdgeRow {
+  id: string;
+  caller_function_id: string;
+  callee_function_id?: string;
+  callee_name: string;
+  callee_signature?: string;
+  call_type: 'direct' | 'conditional' | 'async' | 'external' | 'dynamic';
+  call_context?: string;
+  line_number: number;
+  column_number: number;
+  is_async: boolean;
+  is_chained: boolean;
+  confidence_score: number;
+  metadata: Record<string, unknown>;
+  created_at: string;
+}
+
 // Diff/History related types
 export interface DiffFunction {
   id: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -169,6 +169,23 @@ export interface ParameterInfo {
   description?: string;
 }
 
+export interface CallEdge {
+  id: string;
+  callerFunctionId: string;
+  calleeFunctionId?: string;
+  calleeName: string;
+  calleeSignature?: string;
+  callType: 'direct' | 'conditional' | 'async' | 'external' | 'dynamic';
+  callContext?: string;
+  lineNumber: number;
+  columnNumber: number;
+  isAsync: boolean;
+  isChained: boolean;
+  confidenceScore: number;
+  metadata: Record<string, unknown>;
+  createdAt: string;
+}
+
 export interface ReturnTypeInfo {
   type: string;
   typeSimple: string;


### PR DESCRIPTION
## Summary
- Add `call_edges` table to database schema for function call relationship tracking
- Include comprehensive TypeScript type definitions
- Support for various call types (direct, conditional, async, external, dynamic)
- Performance-optimized indexes for call graph traversal

## Changes Made
- **Database Schema**: Added `call_edges` table to `src/schemas/database.sql`
- **Type Definitions**: Added `CallEdge` and `CallEdgeRow` interfaces in `src/types/`
- **Foreign Key Constraints**: Proper CASCADE and SET NULL behaviors
- **Indexes**: Optimized for caller/callee queries and call type filtering

## Test Plan
- [x] Database migration tested successfully
- [x] funcqc scan works with new schema
- [x] TypeScript compilation passes
- [x] Existing functionality unaffected
- [x] No High Risk functions introduced

## Schema Details
The `call_edges` table supports:
- Function-to-function call relationships
- External library call tracking
- Async/await pattern detection  
- Method chaining analysis
- Call confidence scoring

## Related Issues
- Closes #198
- Part of Epic #197: Call Graph Analysis and Dead Code Detection

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 関数間の呼び出し関係を表現する新しい「call_edges」テーブルが追加されました。
  * 関数呼び出しエッジを表現する新しい型定義が追加されました。

* **ドキュメント**
  * スキーマドキュメントが更新され、新しいテーブルと型情報が反映されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->