### PR TITLE
fix: restore accidentally deleted config files

### DIFF
--- a/.funcqc-arch.yaml
+++ b/.funcqc-arch.yaml
@@ -1,0 +1,124 @@
+# Enhanced architecture configuration for funcqc
+# Based on feedback for allow-based rules with comprehensive layer coverage
+
+layers:
+  # Entry points and user interfaces
+  cli:
+    - "src/cli.ts"
+    - "src/cli/**"
+  
+  # Application orchestration and use case coordination
+  orchestration:
+    - "src/use-cases/**"
+  
+  # Specialized analysis engines and algorithms
+  analysis:
+    - "src/analyzers/**"
+    - "src/similarity/**"
+  
+  # Core domain logic and business rules
+  domain:
+    - "src/core/**"
+    - "src/metrics/**"
+    - "src/refactoring/**"
+  
+  # External service integrations and background processing
+  services:
+    - "src/services/**"
+    - "src/workers/**"
+  
+  # Data persistence and database operations
+  storage:
+    - "src/storage/**"
+    - "src/migrations/**"
+  
+  # Infrastructure, configuration and static data
+  infrastructure:
+    - "src/config/**"
+    - "src/schemas/**"
+    - "src/data/**"
+  
+  # Pure utility functions and tools
+  utils:
+    - "src/utils/**"
+    - "src/tools/**"
+    - "src/visualization/**"
+  
+  # Type definitions (completely independent)
+  types:
+    - "src/types/**"
+
+rules:
+  # CLI layer: Entry point, can depend on orchestration and infrastructure
+  - type: allow
+    from: "cli"
+    to: ["orchestration", "infrastructure", "utils", "types"]
+    description: "CLI can orchestrate use cases and access configuration"
+
+  # Orchestration layer: Coordinates domain operations
+  - type: allow
+    from: "orchestration"
+    to: ["analysis", "domain", "services", "infrastructure", "utils", "types"]
+    description: "Use cases orchestrate analysis, domain logic, and services"
+
+  # Analysis layer: Specialized engines, can use domain logic and services
+  - type: allow
+    from: "analysis"
+    to: ["domain", "services", "storage", "infrastructure", "utils", "types"]
+    description: "Analysis engines can use domain logic and external services"
+
+  # Domain layer: Core business logic, can use storage and utilities
+  - type: allow
+    from: "domain"
+    to: ["storage", "infrastructure", "utils", "types"]
+    description: "Domain logic can persist data and use utilities"
+
+  # Services layer: External integrations, can use storage and utilities
+  - type: allow
+    from: "services"
+    to: ["storage", "infrastructure", "utils", "types"]
+    description: "Services can persist data and use configuration"
+
+  # Storage layer: Data persistence, can use infrastructure and utilities
+  - type: allow
+    from: "storage"
+    to: ["infrastructure", "utils", "types"]
+    description: "Storage can use configuration and utilities"
+
+  # Infrastructure layer: Configuration and schemas, can use utilities
+  - type: allow
+    from: "infrastructure"
+    to: ["utils", "types"]
+    description: "Infrastructure can use utilities for configuration processing"
+
+  # Utils layer: Can only depend on types
+  - type: allow
+    from: "utils"
+    to: ["types"]
+    description: "Utilities are pure functions that only use types"
+
+  # Types layer: Completely independent
+  - type: forbid
+    from: "types"
+    to: "*"
+    description: "Types must be completely independent and self-contained"
+    severity: error
+
+  # Prevent upward dependencies (architectural violations)
+  - type: forbid
+    from: ["orchestration", "analysis", "domain", "services", "storage", "infrastructure", "utils"]
+    to: "cli"
+    description: "Lower layers cannot depend on CLI entry points"
+    severity: error
+
+  - type: forbid
+    from: ["analysis", "domain", "services", "storage", "infrastructure", "utils"]
+    to: "orchestration"
+    description: "Lower layers cannot depend on orchestration layer"
+    severity: error
+
+settings:
+  allowSameLayer: true
+  strictMode: true
+  defaultSeverity: error
+  ignoreExternal: true

--- a/.funcqc.config.js
+++ b/.funcqc.config.js
@@ -1,0 +1,105 @@
+// funcqc configuration
+// See https://github.com/yourusername/funcqc for documentation
+
+module.exports = {
+  "roots": [
+    "src"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/__tests__/**",
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**",
+    "**/coverage/**",
+    "**/.git/**"
+  ],
+  "defaultScope": "src",
+  "globalExclude": [
+    "**/node_modules/**",
+    "**/dist/**",
+    "**/build/**"
+  ],
+  "scopes": {
+    "src": {
+      "roots": [
+        "src"
+      ],
+      "exclude": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/__tests__/**"
+      ],
+      "description": "Production source code"
+    },
+    "test": {
+      "roots": [
+        "test",
+        "src/__tests__"
+      ],
+      "include": [
+        "**/*.test.ts",
+        "**/*.spec.ts",
+        "**/*.test.js",
+        "**/*.spec.js"
+      ],
+      "exclude": [],
+      "description": "Test code files"
+    },
+    "docs": {
+      "roots": [
+        "docs"
+      ],
+      "include": [
+        "**/*.ts",
+        "**/*.js"
+      ],
+      "exclude": [],
+      "description": "Documentation and examples"
+    },
+    "scripts": {
+      "roots": [
+        "scripts",
+        "bin"
+      ],
+      "include": [
+        "**/*.ts",
+        "**/*.js"
+      ],
+      "exclude": [],
+      "description": "Build scripts and tools"
+    },
+    "all": {
+      "roots": [
+        "src",
+        "test",
+        "docs",
+        "scripts",
+        "bin"
+      ],
+      "exclude": [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/build/**",
+        "**/coverage/**"
+      ],
+      "description": "All source, test, and utility code"
+    }
+  },
+  "storage": {
+    "type": "pglite",
+    "path": ".funcqc/funcqc.db"
+  },
+  "metrics": {
+    "complexityThreshold": 10,
+    "cognitiveComplexityThreshold": 15,
+    "linesOfCodeThreshold": 40,
+    "parameterCountThreshold": 4,
+    "maxNestingLevelThreshold": 3
+  },
+  "git": {
+    "enabled": true,
+    "autoLabel": true
+  }
+};

--- a/examples/.funcqc.config.js
+++ b/examples/.funcqc.config.js
@@ -1,0 +1,67 @@
+// funcqc configuration file example
+// Copy this file to .funcqc.config.js in your project root
+
+module.exports = {
+  // Root directories to scan for TypeScript files
+  roots: ['src', 'lib'],
+  
+  // Files and directories to exclude from analysis
+  exclude: [
+    '**/*.test.ts',
+    '**/*.spec.ts',
+    '**/__tests__/**',
+    '**/node_modules/**',
+    '**/dist/**',
+    '**/build/**',
+    '**/*.d.ts'
+  ],
+  
+  // Optional: Files to explicitly include (glob patterns)
+  // include: ['**/*.ts', '**/*.tsx'],
+  
+  // Storage configuration
+  storage: {
+    type: 'pglite', // 'pglite' | 'postgres'
+    path: '.funcqc/funcqc.db', // For PGLite
+    // url: 'postgresql://user:pass@localhost/funcqc' // For PostgreSQL
+  },
+  
+  // Quality metrics thresholds
+  metrics: {
+    complexityThreshold: 10,
+    linesOfCodeThreshold: 50,
+    parameterCountThreshold: 5
+  },
+  
+  // Git integration settings
+  git: {
+    enabled: true,
+    autoLabel: true // Automatically label snapshots with git info
+  },
+  
+  // Similarity detection settings (for future phases)
+  similarity: {
+    detectors: {
+      'builtin-ast': {
+        enabled: true,
+        threshold: 0.8
+      },
+      'mizchi-similarity': {
+        enabled: false, // Enable when available
+        threshold: 0.85,
+        options: {
+          minLines: 5,
+          crossFile: true
+        }
+      }
+    },
+    consensus: {
+      strategy: 'weighted',
+      weightings: {
+        'builtin-ast': 0.8,
+        'mizchi-similarity': 1.0
+      },
+      threshold: 0.7
+    }
+  }
+};


### PR DESCRIPTION
## Problem
Essential configuration files were accidentally deleted in commit 62104f4 while fixing TypeScriptAnalyzer integration.

## Deleted Files
- `.funcqc-arch.yaml` - Architecture layer configuration used by `dep lint` command
- `.funcqc.config.js` - Main funcqc configuration file
- `examples/.funcqc.config.js` - Example configuration for documentation

## Impact
Without these files:
- `dep lint` command would fail with "No architecture layers defined"
- Architecture validation features would not work
- Example configuration would be missing for new users

## Solution
Restored the files from the commit just before they were deleted (62104f4^).

## Verification
- Checked that the files contain the expected configuration
- Verified that `dep lint` and other architecture-related commands would work with these files present