### PR TITLE
Enhance types list command display format

### DIFF
--- a/src/cli/commands/types.ts
+++ b/src/cli/commands/types.ts
@@ -38,8 +38,12 @@ export function createTypesCommand(): Command {
     .option('--sort <field>', 'Sort by field (name|fields|complexity|usage)', 'name')
     .option('--desc', 'Sort in descending order')
     .option('--json', 'Output in JSON format')
-    .action(async (options: TypeListOptions) => {
-      await executeTypesList(options);
+    .option('--detail', 'Show detailed information in multi-line format')
+    .action(async (options: TypeListOptions, command) => {
+      // Merge global options
+      const globalOpts = command.parent?.opts() || {};
+      const mergedOptions = { ...globalOpts, ...options, verbose: options.detail };
+      await executeTypesList(mergedOptions);
     });
 
   // Type health command
@@ -49,8 +53,11 @@ export function createTypesCommand(): Command {
     .option('--verbose', 'Show detailed health information')
     .option('--json', 'Output in JSON format')
     .option('--thresholds <path>', 'Path to custom thresholds file')
-    .action(async (options: TypeHealthOptions) => {
-      await executeTypesHealth(options);
+    .action(async (options: TypeHealthOptions, command) => {
+      // Merge global options
+      const globalOpts = command.parent?.opts() || {};
+      const mergedOptions = { ...globalOpts, ...options };
+      await executeTypesHealth(mergedOptions);
     });
 
   // Type dependencies command
@@ -60,8 +67,11 @@ export function createTypesCommand(): Command {
     .option('--depth <number>', 'Maximum dependency depth to analyze', parseInt, 3)
     .option('--circular', 'Show only circular dependencies')
     .option('--json', 'Output in JSON format')
-    .action(async (typeName: string, options: TypeDepsOptions) => {
-      await executeTypesDeps(typeName, options);
+    .action(async (typeName: string, options: TypeDepsOptions, command) => {
+      // Merge global options
+      const globalOpts = command.parent?.opts() || {};
+      const mergedOptions = { ...globalOpts, ...options };
+      await executeTypesDeps(typeName, mergedOptions);
     });
 
   return typesCmd;
@@ -119,7 +129,7 @@ export async function executeTypesList(options: TypeListOptions): Promise<void> 
     if (options.json) {
       console.log(JSON.stringify(filteredTypes, null, 2));
     } else {
-      displayTypesList(filteredTypes);
+      displayTypesList(filteredTypes, options.verbose);
     }
 
   } catch (error) {

--- a/src/cli/commands/types.ts
+++ b/src/cli/commands/types.ts
@@ -42,7 +42,7 @@ export function createTypesCommand(): Command {
     .action(async (options: TypeListOptions, command) => {
       // Merge global options
       const globalOpts = command.parent?.opts() || {};
-      const mergedOptions = { ...globalOpts, ...options, verbose: options.detail };
+      const mergedOptions = { ...globalOpts, ...options };
       await executeTypesList(mergedOptions);
     });
 
@@ -129,7 +129,7 @@ export async function executeTypesList(options: TypeListOptions): Promise<void> 
     if (options.json) {
       console.log(JSON.stringify(filteredTypes, null, 2));
     } else {
-      displayTypesList(filteredTypes, options.verbose);
+      displayTypesList(filteredTypes, options.detail);
     }
 
   } catch (error) {

--- a/src/cli/commands/types.types.ts
+++ b/src/cli/commands/types.types.ts
@@ -7,6 +7,8 @@ export interface TypeListOptions {
   sort?: 'name' | 'fields' | 'complexity' | 'usage';
   desc?: boolean;
   json?: boolean;
+  verbose?: boolean;
+  detail?: boolean;
 }
 
 export interface TypeHealthOptions {

--- a/src/cli/commands/types.types.ts
+++ b/src/cli/commands/types.types.ts
@@ -7,7 +7,6 @@ export interface TypeListOptions {
   sort?: 'name' | 'fields' | 'complexity' | 'usage';
   desc?: boolean;
   json?: boolean;
-  verbose?: boolean;
   detail?: boolean;
 }
 

--- a/src/cli/commands/utils/type-display.ts
+++ b/src/cli/commands/utils/type-display.ts
@@ -158,7 +158,7 @@ function padOrTruncate(str: string, length: number): string {
  */
 function shortenFilePath(filePath: string, maxLength: number): string {
   // Remove common prefix and shorten
-  const relativePath = filePath.replace('/mnt/c/Users/akira/source/repos/funcqc/', '');
+  const relativePath = filePath.replace(process.cwd() + '/', '');
   const srcPath = relativePath.replace(/^src\//, '');
   
   if (srcPath.length <= maxLength) {

--- a/src/cli/commands/utils/type-display.ts
+++ b/src/cli/commands/utils/type-display.ts
@@ -39,12 +39,56 @@ export function sortTypes(types: TypeDefinition[], sortBy: string, desc?: boolea
 /**
  * Display types list in formatted output
  */
-export function displayTypesList(types: TypeDefinition[]): void {
+export function displayTypesList(types: TypeDefinition[], verbose?: boolean): void {
   if (!types || types.length === 0) {
     console.log('📭 No types found matching the criteria');
     return;
   }
 
+  
+  if (verbose === true) {
+    displayTypesListVerbose(types);
+  } else {
+    displayTypesListTable(types);
+  }
+}
+
+/**
+ * Display types in table format (default)
+ */
+function displayTypesListTable(types: TypeDefinition[]): void {
+  console.log(`\n📋 Found ${types.length} types:\n`);
+  
+  // Table header
+  console.log('ID       Name                         Kind        Exp LOC Props Methods File                          Line');
+  console.log('──────── ──────────────────────────── ─────────── ─── ─── ───── ─────── ───────────────────────────── ────');
+  
+  for (const type of types) {
+    const id = shortenId(type.id);
+    const name = padOrTruncate(type.name, 28);
+    const kind = padOrTruncate(getKindText(type.kind), 11);
+    const exportIcon = type.isExported ? '🌐' : '🔒';
+    const loc = calculateLOC(type);
+    const locStr = loc.toString().padStart(3);
+    
+    // Safe access to metadata properties
+    const metadata = type.metadata || {};
+    const props = ((metadata['propertyCount'] as number) ?? 0).toString().padStart(5);
+    const methods = ((metadata['methodCount'] as number) ?? 0).toString().padStart(7);
+    
+    const file = shortenFilePath(type.filePath, 29);
+    const line = type.startLine.toString().padStart(4);
+    
+    console.log(`${id} ${name} ${kind} ${exportIcon}   ${locStr} ${props} ${methods} ${file} ${line}`);
+  }
+  
+  console.log('');
+}
+
+/**
+ * Display types in verbose format (original multi-line format)
+ */
+function displayTypesListVerbose(types: TypeDefinition[]): void {
   console.log(`\n📋 Found ${types.length} types:\n`);
   
   for (const type of types) {
@@ -56,6 +100,7 @@ export function displayTypesList(types: TypeDefinition[]): void {
     
     console.log(`${kindIcon} ${exportStatus} ${type.name}${genericStatus}`);
     console.log(`   📁 ${type.filePath}:${type.startLine}`);
+    console.log(`   🆔 ${type.id}`);
     
     // Safe access to metadata properties
     const metadata = type.metadata || {};
@@ -68,6 +113,79 @@ export function displayTypesList(types: TypeDefinition[]): void {
     
     console.log('');
   }
+}
+
+/**
+ * Shorten ID for display (first 8 characters)
+ */
+function shortenId(id: string): string {
+  return id.substring(0, 8);
+}
+
+/**
+ * Calculate Lines of Code for a type
+ */
+function calculateLOC(type: TypeDefinition): number {
+  return type.endLine - type.startLine + 1;
+}
+
+/**
+ * Get text representation of type kind
+ */
+function getKindText(kind: string): string {
+  switch (kind) {
+    case 'interface': return 'interface';
+    case 'class': return 'class';
+    case 'type_alias': return 'type';
+    case 'enum': return 'enum';
+    case 'namespace': return 'namespace';
+    default: return kind;
+  }
+}
+
+/**
+ * Pad or truncate string to specified length
+ */
+function padOrTruncate(str: string, length: number): string {
+  if (str.length > length) {
+    return str.substring(0, length - 3) + '...';
+  }
+  return str.padEnd(length);
+}
+
+/**
+ * Shorten file path for display
+ */
+function shortenFilePath(filePath: string, maxLength: number): string {
+  // Remove common prefix and shorten
+  const relativePath = filePath.replace('/mnt/c/Users/akira/source/repos/funcqc/', '');
+  const srcPath = relativePath.replace(/^src\//, '');
+  
+  if (srcPath.length <= maxLength) {
+    return srcPath.padEnd(maxLength);
+  }
+  
+  // Shorten by keeping directory structure readable
+  const parts = srcPath.split('/');
+  if (parts.length > 1) {
+    const fileName = parts[parts.length - 1];
+    const dirParts = parts.slice(0, -1);
+    
+    // Try to fit as much as possible
+    let shortened = fileName;
+    for (let i = dirParts.length - 1; i >= 0; i--) {
+      const candidate = dirParts[i] + '/' + shortened;
+      if (candidate.length <= maxLength - 3) {
+        shortened = candidate;
+      } else {
+        shortened = '...' + shortened;
+        break;
+      }
+    }
+    return shortened.padEnd(maxLength);
+  }
+  
+  return (srcPath.substring(0, maxLength - 3) + '...').padEnd(maxLength);
 }
 
 /**


### PR DESCRIPTION
## Summary
• Add table format as default display for `types list` command with compact columns
• Implement `--detail` option for verbose multi-line format  
• Fix Commander.js option parsing conflict between global and command-specific `--verbose`
• Add ID display for unique type identification and improved readability

## Changes Made
- **Table Display Format**: Compact table showing ID, Name, Kind, Export status, LOC, Props, Methods, File, Line
- **Detail Option**: Added `--detail` flag for original verbose multi-line format with emoji icons
- **ID Display**: Short 8-character ID display for unique type identification
- **LOC Calculation**: Calculate and display Lines of Code for each type
- **Smart File Path Display**: Truncate long paths while preserving readability
- **Option Parsing Fix**: Resolved conflict with global `--verbose` option using `--detail`

## Test Results
```bash
# Table format (default)
$ funcqc types list --limit 2
ID       Name                         Kind        Exp LOC Props Methods File                          Line
──────── ──────────────────────────── ─────────── ─── ─── ───── ─────── ───────────────────────────── ────
f1bca5a4 AdvancedSimilarityDetector   class       🌐   1631    16      63 ...advanced-similarity-detector.ts   35
e1a8458c AIHints                      interface   🔒     5     3       0 cli/commands/search.ts         477

# Detailed format
$ funcqc types list --limit 2 --detail
🏗️ 🌐 AdvancedSimilarityDetector
   📁 /path/to/file.ts:35
   🆔 66ba9d42-7749-4cc8-b23b-28e536d2e7bc
   📊 16 properties, 63 methods
```

## Quality Assurance
- ✅ TypeScript compilation: `npm run typecheck` 
- ✅ ESLint checks: `npm run lint`
- ✅ Functionality testing: Both table and detail formats work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * `types list` コマンドに `--detail` オプションを追加し、詳細なマルチライン表示が可能になりました。
  * 型一覧表示にコンパクトな表形式と詳細表示を切り替えできるようになりました。

* **改善**
  * コマンドのグローバルオプションとローカルオプションの統合処理が標準化されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->