### PR TITLE
Refactor: Unify dead code detection logic between dep dead and dep delete

### DIFF
--- a/src/analyzers/dead-code-analyzer.ts
+++ b/src/analyzers/dead-code-analyzer.ts
@@ -1,0 +1,302 @@
+import { FunctionInfo, CallEdge } from '../types';
+import { EntryPoint, EntryPointDetector, EntryPointDetectionOptions } from './entry-point-detector';
+import { ReachabilityAnalyzer, ReachabilityResult, DeadCodeInfo } from './reachability-analyzer';
+import { FunctionClassifier } from '../utils/function-classifier';
+
+export interface DeadCodeAnalysisOptions {
+  // Entry point detection options
+  verbose?: boolean;
+  debug?: boolean;
+  layerEntryPoints?: string[];
+  excludeStaticMethods?: boolean;
+
+  // Filtering options
+  excludeTests?: boolean;
+  excludeExports?: boolean;
+  excludeSmall?: boolean;
+  threshold?: number; // Minimum function size threshold
+
+  // Additional filters
+  includeStaticMethods?: boolean;
+  excludeHandlers?: boolean;
+  excludeConstructors?: boolean;
+}
+
+export interface DeadCodeAnalysisResult {
+  reachabilityResult: ReachabilityResult;
+  deadCodeInfo: DeadCodeInfo[];
+  unusedExportInfo: DeadCodeInfo[];
+  staticMethodsInfo: {
+    staticMethods: DeadCodeInfo[];
+    byClass: Map<string, DeadCodeInfo[]>;
+  };
+  entryPoints: EntryPoint[];
+  analysisMetadata: {
+    totalFunctions: number;
+    reachableFunctions: number;
+    unreachableFunctions: number;
+    filteredOutFunctions: number;
+    entryPointCount: number;
+    coverage: number;
+  };
+}
+
+/**
+ * Base analyzer for dead code analysis
+ * Provides shared functionality for both dep dead and dep delete commands
+ * 
+ * This class unifies the logic previously scattered between:
+ * - ReachabilityAnalyzer
+ * - EntryPointDetector  
+ * - Individual command implementations
+ */
+export class DeadCodeAnalyzer {
+  private reachabilityAnalyzer: ReachabilityAnalyzer;
+  private entryPointDetector: EntryPointDetector;
+
+  constructor(options: DeadCodeAnalysisOptions = {}) {
+    this.reachabilityAnalyzer = new ReachabilityAnalyzer();
+    
+    // Configure entry point detector based on options
+    const entryPointOptions: EntryPointDetectionOptions = {};
+    
+    if (options.verbose !== undefined) {
+      entryPointOptions.verbose = options.verbose;
+    }
+    if (options.debug !== undefined) {
+      entryPointOptions.debug = options.debug;
+    }
+    if (options.layerEntryPoints !== undefined) {
+      entryPointOptions.layerEntryPoints = options.layerEntryPoints;
+    }
+    if (options.excludeStaticMethods !== undefined) {
+      entryPointOptions.excludeStaticMethods = options.excludeStaticMethods;
+    }
+    
+    this.entryPointDetector = new EntryPointDetector(entryPointOptions);
+  }
+
+  /**
+   * Perform comprehensive dead code analysis
+   */
+  analyzeDeadCode(
+    functions: FunctionInfo[],
+    callEdges: CallEdge[],
+    options: DeadCodeAnalysisOptions = {}
+  ): DeadCodeAnalysisResult {
+    // Step 1: Detect entry points
+    let entryPoints = this.entryPointDetector.detectEntryPoints(functions);
+
+    // Step 2: Apply entry point filters
+    entryPoints = this.filterEntryPoints(entryPoints, options);
+
+    // Step 3: Perform reachability analysis
+    const reachabilityResult = this.reachabilityAnalyzer.analyzeReachability(
+      functions,
+      callEdges,
+      entryPoints
+    );
+
+    // Step 4: Get detailed dead code information with shared filtering
+    const deadCodeInfo = this.getFilteredDeadCodeInfo(
+      reachabilityResult.unreachable,
+      functions,
+      callEdges,
+      options
+    );
+
+    // Step 5: Get unused export information
+    const unusedExportInfo = this.reachabilityAnalyzer.getDeadCodeInfo(
+      reachabilityResult.unusedExports,
+      functions,
+      callEdges,
+      {
+        excludeTests: false,
+        excludeSmallFunctions: false,
+        minFunctionSize: 1,
+      }
+    );
+
+    // Step 6: Get static methods information using shared logic
+    const staticMethodsInfo = this.getStaticMethodsInfo(deadCodeInfo, functions);
+
+    // Step 7: Calculate analysis metadata
+    const analysisMetadata = this.calculateAnalysisMetadata(
+      functions,
+      reachabilityResult,
+      deadCodeInfo
+    );
+
+    return {
+      reachabilityResult,
+      deadCodeInfo,
+      unusedExportInfo,
+      staticMethodsInfo,
+      entryPoints,
+      analysisMetadata,
+    };
+  }
+
+  /**
+   * Filter entry points based on options
+   */
+  private filterEntryPoints(
+    entryPoints: EntryPoint[],
+    options: DeadCodeAnalysisOptions
+  ): EntryPoint[] {
+    let filtered = [...entryPoints];
+
+    if (options.excludeExports) {
+      filtered = filtered.filter(ep => ep.reason !== 'exported');
+    }
+
+    if (options.excludeTests) {
+      filtered = filtered.filter(ep => ep.reason !== 'test');
+    }
+
+    if (options.excludeStaticMethods) {
+      filtered = filtered.filter(ep => ep.reason !== 'static-method');
+    }
+
+    return filtered;
+  }
+
+  /**
+   * Get filtered dead code information using shared logic
+   */
+  private getFilteredDeadCodeInfo(
+    unreachableFunctions: Set<string>,
+    allFunctions: FunctionInfo[],
+    callEdges: CallEdge[],
+    options: DeadCodeAnalysisOptions
+  ): DeadCodeInfo[] {
+    // Use ReachabilityAnalyzer for basic dead code info
+    const basicDeadCodeInfo = this.reachabilityAnalyzer.getDeadCodeInfo(
+      unreachableFunctions,
+      allFunctions,
+      callEdges,
+      {
+        excludeTests: options.excludeTests ?? false,
+        excludeSmallFunctions: options.excludeSmall ?? false,
+        minFunctionSize: options.threshold ? parseInt(String(options.threshold)) : 3,
+      }
+    );
+
+    // Apply additional filters using FunctionClassifier
+    return basicDeadCodeInfo.filter(deadInfo => {
+      const func = allFunctions.find(f => f.id === deadInfo.functionId);
+      if (!func) return true;
+
+      // Filter static methods if requested
+      if (!options.includeStaticMethods && FunctionClassifier.isStaticMethod(func)) {
+        return false;
+      }
+
+      // Filter handlers if requested
+      if (options.excludeHandlers && FunctionClassifier.isHandlerFunction(func)) {
+        return false;
+      }
+
+      // Filter constructors if requested
+      if (options.excludeConstructors && FunctionClassifier.isConstructor(func)) {
+        return false;
+      }
+
+      return true;
+    });
+  }
+
+  /**
+   * Get static methods information using shared classification logic
+   */
+  private getStaticMethodsInfo(
+    deadCodeInfo: DeadCodeInfo[],
+    functions: FunctionInfo[]
+  ): { staticMethods: DeadCodeInfo[]; byClass: Map<string, DeadCodeInfo[]> } {
+    const staticMethods: DeadCodeInfo[] = [];
+    const byClass = new Map<string, DeadCodeInfo[]>();
+
+    for (const deadInfo of deadCodeInfo) {
+      const func = functions.find(f => f.id === deadInfo.functionId);
+      if (!func) continue;
+
+      // Use shared classification logic
+      if (FunctionClassifier.isStaticMethod(func)) {
+        staticMethods.push(deadInfo);
+
+        const className = func.className ?? 
+          (func.contextPath && func.contextPath.length > 0 ? func.contextPath[0] : 'Unknown');
+        
+        if (!byClass.has(className)) {
+          byClass.set(className, []);
+        }
+        byClass.get(className)!.push(deadInfo);
+      }
+    }
+
+    return { staticMethods, byClass };
+  }
+
+  /**
+   * Calculate analysis metadata
+   */
+  private calculateAnalysisMetadata(
+    functions: FunctionInfo[],
+    reachabilityResult: ReachabilityResult,
+    deadCodeInfo: DeadCodeInfo[]
+  ): DeadCodeAnalysisResult['analysisMetadata'] {
+    const totalFunctions = functions.length;
+    const reachableFunctions = reachabilityResult.reachable.size;
+    const unreachableFunctions = reachabilityResult.unreachable.size;
+    const filteredOutFunctions = unreachableFunctions - deadCodeInfo.length;
+    const coverage = (reachableFunctions / totalFunctions) * 100;
+
+    return {
+      totalFunctions,
+      reachableFunctions,
+      unreachableFunctions,
+      filteredOutFunctions,
+      entryPointCount: reachabilityResult.entryPoints.size,
+      coverage,
+    };
+  }
+
+  /**
+   * Check if a function should be considered for deletion
+   * This method can be overridden by subclasses for specific deletion criteria
+   */
+  protected shouldConsiderForDeletion(
+    func: FunctionInfo,
+    options: DeadCodeAnalysisOptions
+  ): boolean {
+    // Base implementation applies common filters
+    const metadata = FunctionClassifier.getMetadata(func);
+
+    // Always exclude exported functions from deletion consideration by default
+    if (metadata.isExported && !options.includeStaticMethods) {
+      return false;
+    }
+
+    // Exclude test functions if requested
+    if (options.excludeTests && metadata.isTest) {
+      return false;
+    }
+
+    // Exclude static methods unless explicitly included
+    if (!options.includeStaticMethods && metadata.isStaticMethod) {
+      return false;
+    }
+
+    // Exclude handlers if requested
+    if (options.excludeHandlers && metadata.isHandler) {
+      return false;
+    }
+
+    // Exclude constructors if requested
+    if (options.excludeConstructors && metadata.isConstructor) {
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/src/analyzers/dependency-analysis-engine.ts
+++ b/src/analyzers/dependency-analysis-engine.ts
@@ -16,6 +16,10 @@ export interface DependencyAnalysisOptions {
   dryRun: boolean;               // Only analyze without making changes (default: true)
   storage?: import('../types').StorageAdapter; // Storage adapter for internal call edge queries
   snapshotId?: string;           // Snapshot ID for consistent data access
+  
+  // Additional filtering options for enhanced analysis
+  includeStaticMethods?: boolean;  // Include static methods in analysis (default: false)
+  excludeTests?: boolean;         // Exclude test functions from analysis (default: false)
 }
 
 /**

--- a/src/utils/function-classifier.ts
+++ b/src/utils/function-classifier.ts
@@ -1,0 +1,178 @@
+import { FunctionInfo } from '../types';
+
+/**
+ * Utility class for classifying and identifying function types
+ * Provides common logic shared between dep dead and dep delete commands
+ */
+export class FunctionClassifier {
+  /**
+   * Check if a function is a static method
+   */
+  static isStaticMethod(func: FunctionInfo): boolean {
+    return func.isMethod === true && 
+      (func.isStatic === true || func.modifiers?.includes('static') === true);
+  }
+
+  /**
+   * Check if a function is an instance method (non-static method)
+   */
+  static isInstanceMethod(func: FunctionInfo): boolean {
+    return func.isMethod === true && !this.isStaticMethod(func);
+  }
+
+  /**
+   * Check if a function is a constructor
+   */
+  static isConstructor(func: FunctionInfo): boolean {
+    return func.isConstructor === true || 
+      func.name === 'constructor' || 
+      func.modifiers?.includes('constructor') === true;
+  }
+
+  /**
+   * Check if a function is exported
+   */
+  static isExported(func: FunctionInfo): boolean {
+    return func.isExported === true;
+  }
+
+  /**
+   * Check if a function is in a test file or is a test function
+   */
+  static isTestFunction(func: FunctionInfo): boolean {
+    // Check if file is a test file
+    const isTestFile = this.isTestFile(func.filePath);
+    
+    // Check if function name suggests it's a test function
+    const isTestFunctionName = /^(test|it|describe|beforeAll|beforeEach|afterAll|afterEach|expect|jest|vitest|suite|setup|teardown)/.test(func.name);
+    
+    return isTestFile || isTestFunctionName;
+  }
+
+  /**
+   * Check if a file is a test file based on path patterns
+   */
+  static isTestFile(filePath: string): boolean {
+    const testPatterns = [
+      /\.test\.[jt]sx?$/,        // .test.ts, .test.js, .test.tsx, .test.jsx
+      /\.spec\.[jt]sx?$/,        // .spec.ts, .spec.js, .spec.tsx, .spec.jsx
+      /(\/|\\)__tests__(\/|\\)/, // /__tests__/ or \__tests__\ (Windows/Unix)
+      /(\/|\\)test(\/|\\)/,      // /test/ or \test\ (Windows/Unix)
+      /(\/|\\)tests(\/|\\)/,     // /tests/ or \tests\ (Windows/Unix)
+      /(\/|\\)e2e(\/|\\)/,       // /e2e/ or \e2e\ (Windows/Unix)
+      /cypress\//,               // Cypress test files
+      /playwright\//,            // Playwright test files
+      /vitest\//,                // Vitest test files
+      /jest\//,                  // Jest test files
+      /\.integration\.[jt]sx?$/, // .integration.ts, .integration.js, etc.
+      /\.e2e\.[jt]sx?$/,         // .e2e.ts, .e2e.js, etc.
+    ];
+
+    return testPatterns.some(pattern => pattern.test(filePath));
+  }
+
+  /**
+   * Check if a function is a CLI command or handler
+   */
+  static isCliFunction(func: FunctionInfo): boolean {
+    const cliPatterns = [
+      /cli\.ts$/,
+      /cli\/.*\.ts$/,
+      /bin\/.*\.(ts|js)$/,
+      /scripts\/.*\.(ts|js)$/,
+    ];
+
+    const isCliFile = cliPatterns.some(pattern => pattern.test(func.filePath));
+    const isCliFunction = /^(command|handler|cli|main|run)/.test(func.name);
+
+    return isCliFile || isCliFunction;
+  }
+
+  /**
+   * Check if a function is a handler (e.g., event handler, API handler)
+   */
+  static isHandlerFunction(func: FunctionInfo): boolean {
+    const handlerPatterns = [
+      /handler/i,
+      /^handle/i,
+      /^on[A-Z]/,  // onClick, onSubmit, etc.
+      /middleware/i,
+      /controller/i,
+      /route/i,
+    ];
+
+    const isHandlerFile = handlerPatterns.some(pattern => pattern.test(func.filePath));
+    const isHandlerFunction = handlerPatterns.some(pattern => pattern.test(func.name));
+
+    return isHandlerFile || isHandlerFunction;
+  }
+
+  /**
+   * Check if a function is in an index file (likely an entry point)
+   */
+  static isIndexFunction(func: FunctionInfo): boolean {
+    const indexPatterns = [
+      /index\.[jt]sx?$/,
+      /main\.[jt]sx?$/,
+    ];
+
+    return indexPatterns.some(pattern => pattern.test(func.filePath));
+  }
+
+  /**
+   * Get a human-readable classification of the function
+   */
+  static getClassification(func: FunctionInfo): string[] {
+    const classifications: string[] = [];
+
+    if (this.isConstructor(func)) classifications.push('constructor');
+    if (this.isStaticMethod(func)) classifications.push('static-method');
+    if (this.isInstanceMethod(func)) classifications.push('instance-method');
+    if (this.isExported(func)) classifications.push('exported');
+    if (this.isTestFunction(func)) classifications.push('test');
+    if (this.isCliFunction(func)) classifications.push('cli');
+    if (this.isHandlerFunction(func)) classifications.push('handler');
+    if (this.isIndexFunction(func)) classifications.push('index');
+
+    if (classifications.length === 0) {
+      classifications.push('regular');
+    }
+
+    return classifications;
+  }
+
+  /**
+   * Get function metadata for analysis
+   */
+  static getMetadata(func: FunctionInfo): {
+    isStaticMethod: boolean;
+    isInstanceMethod: boolean;
+    isConstructor: boolean;
+    isExported: boolean;
+    isTest: boolean;
+    isCli: boolean;
+    isHandler: boolean;
+    isIndex: boolean;
+    classifications: string[];
+    className?: string;
+  } {
+    const metadata = {
+      isStaticMethod: this.isStaticMethod(func),
+      isInstanceMethod: this.isInstanceMethod(func),
+      isConstructor: this.isConstructor(func),
+      isExported: this.isExported(func),
+      isTest: this.isTestFunction(func),
+      isCli: this.isCliFunction(func),
+      isHandler: this.isHandlerFunction(func),
+      isIndex: this.isIndexFunction(func),
+      classifications: this.getClassification(func),
+    } as const;
+
+    // Add className only if it exists
+    if (func.className !== undefined) {
+      return { ...metadata, className: func.className };
+    }
+
+    return metadata;
+  }
+}

--- a/test/utils/function-classifier.test.ts
+++ b/test/utils/function-classifier.test.ts
@@ -4,20 +4,44 @@ import { FunctionInfo } from '../../src/types';
 
 // Mock FunctionInfo for testing
 const createMockFunction = (overrides: Partial<FunctionInfo> = {}): FunctionInfo => ({
+  // 物理識別
   id: 'test-id',
-  name: 'testFunction',
-  filePath: '/test/file.ts',
+  snapshotId: 'snap-1',
   startLine: 1,
   endLine: 10,
-  cyclomaticComplexity: 1,
-  parameters: [],
-  returnType: 'void',
+  startColumn: 0,
+  endColumn: 1,
+  positionId: 'pos-1',
+  // 意味識別
+  semanticId: 'sem-1',
+  name: 'testFunction',
+  displayName: 'testFunction',
+  signature: 'function testFunction(): void',
+  filePath: '/test/file.ts',
+  contextPath: [],
+  functionType: 'function',
+  modifiers: [],
+  nestingLevel: 0,
+  className: undefined,
+  // 関数属性
   isExported: false,
   isAsync: false,
+  isGenerator: false,
+  isArrowFunction: false,
   isMethod: false,
-  isStatic: false,
   isConstructor: false,
-  modifiers: [],
+  isStatic: false,
+  accessModifier: undefined,
+  // 内容識別
+  contentId: 'content-1',
+  astHash: 'ast-1',
+  signatureHash: 'sig-1',
+  // 効率化
+  fileHash: 'file-1',
+  fileContentHash: 'filec-1',
+  // Relations
+  parameters: [],
+  dependencies: [],
   ...overrides,
 });
 

--- a/test/utils/function-classifier.test.ts
+++ b/test/utils/function-classifier.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from 'vitest';
+import { FunctionClassifier } from '../../src/utils/function-classifier';
+import { FunctionInfo } from '../../src/types';
+
+// Mock FunctionInfo for testing
+const createMockFunction = (overrides: Partial<FunctionInfo> = {}): FunctionInfo => ({
+  id: 'test-id',
+  name: 'testFunction',
+  filePath: '/test/file.ts',
+  startLine: 1,
+  endLine: 10,
+  cyclomaticComplexity: 1,
+  parameters: [],
+  returnType: 'void',
+  isExported: false,
+  isAsync: false,
+  isMethod: false,
+  isStatic: false,
+  isConstructor: false,
+  modifiers: [],
+  ...overrides,
+});
+
+describe('FunctionClassifier', () => {
+  describe('isStaticMethod', () => {
+    it('should identify static methods using isStatic flag', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        isStatic: true,
+      });
+      
+      expect(FunctionClassifier.isStaticMethod(func)).toBe(true);
+    });
+
+    it('should identify static methods using modifiers array', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        modifiers: ['static', 'public'],
+      });
+      
+      expect(FunctionClassifier.isStaticMethod(func)).toBe(true);
+    });
+
+    it('should not identify regular methods as static', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        isStatic: false,
+      });
+      
+      expect(FunctionClassifier.isStaticMethod(func)).toBe(false);
+    });
+
+    it('should not identify non-methods as static methods', () => {
+      const func = createMockFunction({
+        isMethod: false,
+        isStatic: true,
+      });
+      
+      expect(FunctionClassifier.isStaticMethod(func)).toBe(false);
+    });
+  });
+
+  describe('isInstanceMethod', () => {
+    it('should identify instance methods', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        isStatic: false,
+      });
+      
+      expect(FunctionClassifier.isInstanceMethod(func)).toBe(true);
+    });
+
+    it('should not identify static methods as instance methods', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        isStatic: true,
+      });
+      
+      expect(FunctionClassifier.isInstanceMethod(func)).toBe(false);
+    });
+  });
+
+  describe('isConstructor', () => {
+    it('should identify constructors using isConstructor flag', () => {
+      const func = createMockFunction({
+        isConstructor: true,
+      });
+      
+      expect(FunctionClassifier.isConstructor(func)).toBe(true);
+    });
+
+    it('should identify constructors using name', () => {
+      const func = createMockFunction({
+        name: 'constructor',
+      });
+      
+      expect(FunctionClassifier.isConstructor(func)).toBe(true);
+    });
+
+    it('should identify constructors using modifiers', () => {
+      const func = createMockFunction({
+        modifiers: ['constructor'],
+      });
+      
+      expect(FunctionClassifier.isConstructor(func)).toBe(true);
+    });
+  });
+
+  describe('isExported', () => {
+    it('should identify exported functions', () => {
+      const func = createMockFunction({
+        isExported: true,
+      });
+      
+      expect(FunctionClassifier.isExported(func)).toBe(true);
+    });
+
+    it('should identify non-exported functions', () => {
+      const func = createMockFunction({
+        isExported: false,
+      });
+      
+      expect(FunctionClassifier.isExported(func)).toBe(false);
+    });
+  });
+
+  describe('isTestFunction', () => {
+    it('should identify test functions by file path', () => {
+      const func = createMockFunction({
+        filePath: '/test/file.test.ts',
+      });
+      
+      expect(FunctionClassifier.isTestFunction(func)).toBe(true);
+    });
+
+    it('should identify test functions by name', () => {
+      const func = createMockFunction({
+        name: 'testSomething',
+      });
+      
+      expect(FunctionClassifier.isTestFunction(func)).toBe(true);
+    });
+
+    it('should identify spec files', () => {
+      const func = createMockFunction({
+        filePath: '/src/component.spec.ts',
+      });
+      
+      expect(FunctionClassifier.isTestFunction(func)).toBe(true);
+    });
+
+    it('should identify __tests__ directory', () => {
+      const func = createMockFunction({
+        filePath: '/src/__tests__/component.ts',
+      });
+      
+      expect(FunctionClassifier.isTestFunction(func)).toBe(true);
+    });
+
+    it('should not identify regular functions as test functions', () => {
+      const func = createMockFunction({
+        filePath: '/src/component.ts',
+        name: 'processData',
+      });
+      
+      expect(FunctionClassifier.isTestFunction(func)).toBe(false);
+    });
+  });
+
+  describe('isTestFile', () => {
+    const testFilePaths = [
+      '/test/file.test.ts',
+      '/test/file.spec.js',
+      '/src/__tests__/component.ts',
+      '/cypress/integration/test.ts',
+      '/test/unit/file.integration.ts',
+      '/e2e/test.e2e.js',
+    ];
+
+    testFilePaths.forEach(filePath => {
+      it(`should identify test file: ${filePath}`, () => {
+        expect(FunctionClassifier.isTestFile(filePath)).toBe(true);
+      });
+    });
+
+    const regularFilePaths = [
+      '/src/component.ts',
+      '/src/utils/helper.js',
+      '/lib/index.ts',
+    ];
+
+    regularFilePaths.forEach(filePath => {
+      it(`should not identify regular file as test: ${filePath}`, () => {
+        expect(FunctionClassifier.isTestFile(filePath)).toBe(false);
+      });
+    });
+  });
+
+  describe('getClassification', () => {
+    it('should return multiple classifications', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        isStatic: true,
+        isExported: true,
+        filePath: '/src/index.ts',
+      });
+      
+      const classifications = FunctionClassifier.getClassification(func);
+      
+      expect(classifications).toContain('static-method');
+      expect(classifications).toContain('exported');
+      expect(classifications).toContain('index');
+    });
+
+    it('should return regular for functions with no special characteristics', () => {
+      const func = createMockFunction({
+        filePath: '/src/utils.ts',
+        name: 'helper',
+      });
+      
+      const classifications = FunctionClassifier.getClassification(func);
+      
+      expect(classifications).toEqual(['regular']);
+    });
+  });
+
+  describe('getMetadata', () => {
+    it('should return comprehensive metadata', () => {
+      const func = createMockFunction({
+        isMethod: true,
+        isStatic: true,
+        isExported: true,
+        className: 'TestClass',
+      });
+      
+      const metadata = FunctionClassifier.getMetadata(func);
+      
+      expect(metadata.isStaticMethod).toBe(true);
+      expect(metadata.isInstanceMethod).toBe(false);
+      expect(metadata.isExported).toBe(true);
+      expect(metadata.className).toBe('TestClass');
+      expect(metadata.classifications).toContain('static-method');
+      expect(metadata.classifications).toContain('exported');
+    });
+
+    it('should handle functions without className', () => {
+      const func = createMockFunction({
+        name: 'regularFunction',
+        filePath: '/src/utils/helper.ts', // Use non-test file path
+      });
+      
+      const metadata = FunctionClassifier.getMetadata(func);
+      
+      expect(metadata).not.toHaveProperty('className');
+      expect(metadata.classifications).toEqual(['regular']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Extract shared logic into `DeadCodeAnalyzer` base class to eliminate code duplication
- Create `FunctionClassifier` utility for consistent function type identification across commands
- Update both `dep dead` and `dep delete` to use shared classification logic
- Ensure static method detection fixes automatically apply to both commands

## Key Changes
### 🔧 New Shared Components
- **`DeadCodeAnalyzer`**: Base class providing unified dead code analysis logic
- **`FunctionClassifier`**: Utility class for consistent function classification (static methods, exports, tests, etc.)

### 🔄 Command Updates  
- **`dep dead`**: Refactored to use `DeadCodeAnalyzer` for reachability analysis
- **`dep delete`**: Updated `SafeDeletionCandidateGenerator` to use `FunctionClassifier`

### ✅ Quality Improvements
- Eliminates code duplication between commands
- Ensures consistent function classification logic
- Makes static method detection fixes (like PR #348) automatically apply to both commands
- Maintains full backward compatibility

## Test Plan
- [x] All existing tests pass
- [x] New comprehensive tests for `FunctionClassifier` utility
- [x] Both `dep dead` and `dep delete` commands work as expected
- [x] TypeScript compilation succeeds
- [x] Static method detection now consistent across both commands

## Impact
- **No breaking changes** - all existing functionality preserved
- **Improved maintainability** - shared logic reduces maintenance burden
- **Enhanced consistency** - both commands now use identical classification criteria
- **Future-proof** - improvements to detection logic automatically benefit both commands

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 単一実行での死活コード分析を追加し、到達可能性・未使用エクスポート・静的メソッド集計・分析メタデータを出力
  - フィルター追加（テスト/エクスポート/静的メソッド/小規模関数の除外、しきい値、レイヤーエントリーポイント）、詳細/デバッグ出力オプション
- リファクタ
  - CLIの解析フローと出力構造を統合・整理し、ステータスメッセージを更新
  - 依存分析のオプションに静的メソッド含有・テスト除外を追加
- テスト
  - 関数分類ユーティリティの網羅的ユニットテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->